### PR TITLE
fix: set postcss version and add baseurl

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: true
 
       - name: Install autoprefixer and PostCSS
-        run: npm install -D --save autoprefixer && npm install -D --save postcss-cli
+        run: npm install -D --save autoprefixer && npm install -D --save postcss-cli@5.0.1
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://stone-co.github.io"
 title = "Stone OpenBank"
 
 enableRobotsTXT = true


### PR DESCRIPTION
apparently versions of PostCSS later than 5.0.1 will not load autoprefixer in some situations so I'm setting a specific version