### PR TITLE
chore: add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# code owners padrão de todo o repositório:
+* @CalebeEmerick @pedroyremolo @erikacarvalho
+
+
+# code owners padrão da pasta que contém o conteúdo:
+content/ @CalebeEmerick @agabiandrade @pedroyremolo @erikacarvalho


### PR DESCRIPTION
this PR adds `CODEOWNER` file, which sets the default code owners for this repository and the `/content` folder