### PR TITLE
chore: fix cname information at deploy action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,3 +48,4 @@ jobs:
           PUBLISH_DIR: ./public
           emptyCommits: false
           commitMessage: ${{ github.event.head_commit.message }}
+          cname: docs.openbank.stone.com.br


### PR DESCRIPTION
Corrige o deploy informando qual CNAME vamos usar no repostório que contém HTMLs.