### PR TITLE
fix: return page titles

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://stone-co.github.io/"
-title = "Stone Openbank"
+title = "Stone OpenBank"
 
 enableRobotsTXT = true
 

--- a/config.toml
+++ b/config.toml
@@ -53,7 +53,7 @@ anchor = "smart"
 
 [languages]
 [languages.pt]
-title = "Stone Openbank"
+title = "Stone OpenBank"
 description = "Escreva o Banco do futuro. Uma linha de código por vez."
 languageName ="Português"
 # Weight used for sorting.

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://stone-co.github.io/"
-title = "Stone OpenBank"
+title = "Stone Openbank"
 
 enableRobotsTXT = true
 
@@ -53,7 +53,7 @@ anchor = "smart"
 
 [languages]
 [languages.pt]
-title = ""
+title = "Stone Openbank"
 description = "Escreva o Banco do futuro. Uma linha de código por vez."
 languageName ="Português"
 # Weight used for sorting.


### PR DESCRIPTION
Return page titles, fixing a problem wherein main no browser title was being shown.