### PR TITLE
refact: change markdown syntax highlighting theme

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -68,7 +68,7 @@ time_format_default = "02.01.2006"
       unsafe = true
   [markup.highlight]
       # See a complete list of available styles at https://xyproto.github.io/splash/docs/all.html
-      style = "tango"
+      style = "dracula"
       # Uncomment if you want your chosen highlight style used for code blocks without a specified language
       # guessSyntax = "true"
 
@@ -83,7 +83,7 @@ copyright = "Stone"
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
-version_menu = "Releases"
+version_menu = "Ambiente"
 
 # Flag used in the "version-banner" partial to decide whether to display a 
 # banner on every page indicating that this is an archived version of the docs.


### PR DESCRIPTION
## Description

Currently, the syntax highlighting theme follows a light style. We want it to be dark (dark is good, light brings bugs).
