### PR TITLE
fix: fix base url issue for i18n

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://stone-co.github.io"
+baseURL = "https://stone-co.github.io/"
 relativeURLs = true
 title = "Stone OpenBank"
 


### PR DESCRIPTION
## Description

Due to recent i18n problems in production, we need to fix the current baseURL to match 301 before redirecting to our CNAME(https://docs.openbank.stone.com.br)