### PR TITLE
feat: show barcode invoice payment limits

### DIFF
--- a/content/pt/docs/referencia-da-api/pagamentos/exibir-limites-de-valores-para-emissao-de-pagamento/_index.pt.md
+++ b/content/pt/docs/referencia-da-api/pagamentos/exibir-limites-de-valores-para-emissao-de-pagamento/_index.pt.md
@@ -19,7 +19,7 @@ GET https://sandbox-api.openbank.stone.com.br/api/v1/barcode_payment_invoices/li
 
 <br>
 
-**account_id\*** `string`
+**account_id*** `string`
 
 Identificador da conta.
 

--- a/content/pt/docs/referencia-da-api/pagamentos/exibir-limites-de-valores-para-emissao-de-pagamento/_index.pt.md
+++ b/content/pt/docs/referencia-da-api/pagamentos/exibir-limites-de-valores-para-emissao-de-pagamento/_index.pt.md
@@ -1,0 +1,44 @@
+---
+title: "Exibir Limites De Valores Para Emissão De Pagamento"
+linkTitle: "Exibir Limites De Valores Para Emissão De Pagamento"
+slug: "exibir-limites-de-pagamento"
+date: 2021-12-09T18:21:13-03:00
+lastmod: 2021-12-09T18:21:13-03:00
+weight: 4
+---
+
+```
+GET https://sandbox-api.openbank.stone.com.br/api/v1/barcode_payment_invoices/limits/:account_id
+```
+
+---
+
+#### **QUERY PARAMS**
+
+---
+
+<br>
+
+**account_id\*** `string`
+
+Identificador da conta.
+
+---
+
+<br>
+
+##### **Response**
+
+```json
+200 OK
+```
+
+Body
+
+```json
+{
+  "account_id": "477f8576-ca82-462b-be73-dc28cc6490c3",
+  "maximum_amount": 2000000,
+  "minimum_amount": 2000
+}
+```


### PR DESCRIPTION
## Description

Documentando [esse endpoint](https://github.com/dlpco/banking-transfers/pull/2784) que mostra os limites de barcode payment invoices. Fiquei um pouco em dúvida de onde botar isso na documentação, se botava em pagamentos ou na seção da Conta, já que esse limite é associado à conta.  
