### PR TITLE
fix: change name open banking to api banking

### DIFF
--- a/content/pt/docs/_index.md
+++ b/content/pt/docs/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Stone Openbank"
-linkTitle: "Stone Openbank"
+title: "Stone API Banking"
+linkTitle: "Stone API Banking"
 date: 2020-09-17T18:00:00-03:00
 lastmod: 2020-09-17T18:00:00-03:00
 weight: 1

--- a/content/pt/docs/guias/APROVACAO/_index.md
+++ b/content/pt/docs/guias/APROVACAO/_index.md
@@ -12,7 +12,7 @@ description: >
 
 ## Overview
 
-No Open Banking, uma plataforma poderá criar uma transação na conta do usuário, mas esta só será efetuada se houver a aprovação do usuário dono da conta. Esse procedimento assegura ao dono da conta que não haverá movimentação de seu dinheiro sem sua permissão, além de proteger a aplicação de eventuais erros, ataques ou bugs que iniciem transações não desejadas pelo usuário.
+No Stone Banking, uma plataforma poderá criar uma transação na conta do usuário, mas esta só será efetuada se houver a aprovação do usuário dono da conta. Esse procedimento assegura ao dono da conta que não haverá movimentação de seu dinheiro sem sua permissão, além de proteger a aplicação de eventuais erros, ataques ou bugs que iniciem transações não desejadas pelo usuário.
 
 A aprovação de uma transação tem como objetivo garantir que toda movimentação financeira de saída de uma conta seja feita somente por um usuário devidamente autorizado. É um procedimento em que o usuário que já concedeu o consentimento é notificado da criação de uma transação e direcionado para uma página onde é possível visualizar todas as transações criadas pelo parceiro. Nessa página é possível aprovar ou rejeitar uma transação, possibilitando ou impedindo sua realização. É importante lembrar que apenas aplicativos que tenham obtido [consentimento]({{< relref "/docs/guias/consentimento">}}) podem criar transações.
 

--- a/content/pt/docs/guias/STONE-OPEN-BANKING/_index.md
+++ b/content/pt/docs/guias/STONE-OPEN-BANKING/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "STONE OPEN BANKING"
-linkTitle: "STONE OPEN BANKING"
+title: "STONE API BANKING"
+linkTitle: "STONE API BANKING"
 date: 2021-08-05T15:40:00-03:00
 lastmod: 2021-08-05T15:40:00-03:00
 weight: 1
@@ -16,14 +16,14 @@ description: >
 
 <br>
 
-**Seja bem-vindo à documentação de Open Banking da Stone!**
+**Seja bem-vindo à documentação da API de Banking da Stone!**
 <br>
 
 Segundo o Banco Central, o Open Banking / Open Finance, ou sistema financeiro aberto, é a possibilidade de clientes de produtos e serviços financeiros permitirem o compartilhamento de suas informações entre diferentes instituições autorizadas pelo Banco Central e a movimentação de suas contas bancárias a partir de diferentes plataformas e não apenas pelo aplicativo ou site do banco, de forma segura, ágil e conveniente.
 
-Como na Stone somos fiéis defensores da competição e temos o cliente como nossa razão de existir, acreditamos na revolução proporcionada por esse sistema e construímos a primeira API de Open Banking plugada diretamente no coração do STR. Acreditamos que nosso produto poderá gerar novos modelos de negócios, dar maior controle e transparência, além de permitir automatizações e ganho de eficiência para as empresas. 
+Como na Stone somos fiéis defensores da competição e temos o cliente como nossa razão de existir, acreditamos na revolução proporcionada por esse sistema e construímos a primeira API de Banking plugada diretamente no coração do STR. Acreditamos que nosso produto poderá gerar novos modelos de negócios, dar maior controle e transparência, além de permitir automatizações e ganho de eficiência para as empresas. 
 
-A partir da integração e do uso da API Stone Open Banking, você poderá movimentar a sua própria conta Stone por meio de uma API RESTful com todas as funcionalidades de cash-in e cash-out. Caso você tenha uma plataforma, também poderá solicitar acesso a contas terceiras para disponibilizar funcionalidades financeiras e agregar ainda mais valor ao seu produto. É claro que para acessar e iniciar transações em contas terceiras, será preciso obter o Consentimento do usuário dono da conta, um conceito essencial para o bom funcionamento do Open Banking.
+A partir da integração e do uso da API Stone Banking, você poderá movimentar a sua própria conta Stone por meio de uma API RESTful com todas as funcionalidades de cash-in e cash-out. Caso você tenha uma plataforma, também poderá solicitar acesso a contas terceiras para disponibilizar funcionalidades financeiras e agregar ainda mais valor ao seu produto. É claro que para acessar e iniciar transações em contas terceiras, será preciso obter o Consentimento do usuário dono da conta, um conceito essencial para o bom funcionamento do Open Banking.
 
 Nesta documentação, você pode explorar todos os produtos e funcionalidades que a nossa API oferece! Além disso, como todas as chamadas em nossa API deverão ser autenticadas para identificação do sujeito de cada ação, vamos detalhar como funciona o acesso via token. 
 <br>

--- a/content/pt/docs/guias/TOKEN-DE-ACESSO/_index.md
+++ b/content/pt/docs/guias/TOKEN-DE-ACESSO/_index.md
@@ -14,7 +14,7 @@ description: >
 ---
 
 <br>
-Para realizar chamadas na API Stone Open Banking, será necessário ter em mãos um Token de Acesso ou Access Token. 
+Para realizar chamadas na API Stone API Banking, será necessário ter em mãos um Token de Acesso ou Access Token. 
 <br>O Token de Acesso gerado será no formato JWT e funcionará como uma chave de acesso para todas as requisições na API. 
 
 <br>

--- a/content/pt/docs/guias/WEBHOOKS/_index.md
+++ b/content/pt/docs/guias/WEBHOOKS/_index.md
@@ -16,7 +16,7 @@ description: >
 ---
 <br>
 
-A ocorrência de certos eventos pode ser importante em diversos fluxos na integração de uma aplicação com a API Stone Open Banking. Por isso, utilizamos webhooks para notificar as aplicações integradas da ocorrência desses eventos.
+A ocorrência de certos eventos pode ser importante em diversos fluxos na integração de uma aplicação com a Stone API Banking. Por isso, utilizamos webhooks para notificar as aplicações integradas da ocorrência desses eventos.
 
 Para sua utilização, é preciso que a aplicação tenha cadastrado no [formulário]({{< relref "/docs/guias/stone-open-banking/#testes-em-sandbox">}}) a URI para a qual enviaremos um POST com os dados do evento. A aplicação deverá estar preparada para lidar com cada evento de forma adequada.
 

--- a/content/pt/docs/referencia-da-api/padroes-da-api/_index.md
+++ b/content/pt/docs/referencia-da-api/padroes-da-api/_index.md
@@ -10,23 +10,23 @@ description: >
 <br>
 <br>
 
-**Sejam bem-vindos à seção de Referências da Stone OpenBank API.**
+**Sejam bem-vindos à seção de Referências da API de Banking da Stone.**
 
 Através da nossa API é possível ter funcionalidades de internet banking e de apps de banco no seu negócio!
 
 <br>
 
-## O que é a Stone OpenBank API
+## O que é a Stone API Banking
 ---
 
 <br>
 
 Aqui na Stone a gente acredita não apenas que o **cliente** tem razão, mas que ele **é a nossa razão**. Somos fiéis defensores da competição e acreditamos que isso melhora o mercado como um todo, o que, por sua vez, melhora a vida da nossa razão.
 
-**Foi com base nesse sentimento pró-competição que montamos a Stone OpenBank API: a primeira API de Open Banking plugada diretamente no STR.**
+**Foi com base nesse sentimento pró-competição que montamos a Stone API Banking: a primeira API de Banking plugada diretamente no STR.**
 A [Conta Stone]({{< relref "/docs/guias/conta-de-pagamento/" >}}) é a nossa oferta para clientes PJ e PF, tanto para aqueles que já pertencem a base da Stone Adquirente, como para aqueles que utilizam outras adquirentes e buscam uma nova forma de se relacionar com sua conta.
   
-O Aplicativo da Conta Stone é mais um parceiro da Stone OpenBank API, usando exatamente os mesmos acessos e APIs descritos nesse documento. \"Eat your own dogfood\" aplicado na prática.
+O Aplicativo da Conta Stone é mais um parceiro da Stone API Banking, usando exatamente os mesmos acessos e APIs descritos nesse documento. \"Eat your own dogfood\" aplicado na prática.
 
 Assim como nós pudemos criar o nosso aplicativo de conta em cima dessa API, você pode fazer o mesmo ou integrar as funcionalidades de automação bancária no seu negócio.
 

--- a/content/pt/docs/referencia-da-api/pagamentos/criar-um-pagamento/_index.md
+++ b/content/pt/docs/referencia-da-api/pagamentos/criar-um-pagamento/_index.md
@@ -12,7 +12,7 @@ description: >
 
 <br>
 
-Usado para realizar pagamentos de boleto e concessionárias.
+Usado para realizar pagamentos de boleto e concessionárias.i
 
 
 <br>


### PR DESCRIPTION
## Description

change name "open banking" to "api banking". It is necessary because "open bank" was registered by Santander
 
