### PR TITLE
fix:remove-operations

### DIFF
--- a/content/pt/docs/referencia-da-api/operacoes/_index.md
+++ b/content/pt/docs/referencia-da-api/operacoes/_index.md
@@ -3,6 +3,6 @@ title: "OPERAÇÕES"
 linkTitle: "OPERAÇÕES"
 lastmod: 2022-01-13T18:00:00-03:00
 weight: 16
-draft: false
+draft: true
 description: >
 ---

--- a/content/pt/docs/referencia-da-api/operacoes/aprovar-operacoes/_index.md
+++ b/content/pt/docs/referencia-da-api/operacoes/aprovar-operacoes/_index.md
@@ -1,10 +1,11 @@
 ---
 title: "Aprovar Operações em Lote"
 slug: "aprovar-operacoes"
+hidden: true
 date: 2022-01-13T18:00:00.687Z
 lastmod: 2022-01-13T18:00:00.687Z
 weight: 2
-draft: false
+draft: true
 description: >
 
 ---

--- a/content/pt/docs/referencia-da-api/operacoes/cancelar-operacoes/_index.md
+++ b/content/pt/docs/referencia-da-api/operacoes/cancelar-operacoes/_index.md
@@ -1,10 +1,11 @@
 ---
 title: "Cancelar Operações em Lote"
 slug: "cancelar-operacoes"
+hidden: true
 date: 2022-01-13T18:00:00.687Z
 lastmod: 2022-01-13T18:00:00.687Z
 weight: 2
-draft: false
+draft: true
 description: >
 
 ---

--- a/content/pt/docs/referencia-da-api/operacoes/detalhes-operacoes/_index.md
+++ b/content/pt/docs/referencia-da-api/operacoes/detalhes-operacoes/_index.md
@@ -1,10 +1,11 @@
 ---
 title: "Detalhe de Operações"
 slug: "detalhes-operacoes"
-hidden: false
+hidden: true
 date: 2022-01-13T18:00:00.687Z
 lastmod: 2022-01-13T18:00:00.687Z
 weight: 3
+draft: true
 ---
 
 <br>

--- a/content/pt/docs/referencia-da-api/operacoes/lista-de-operacoes/_index.md
+++ b/content/pt/docs/referencia-da-api/operacoes/lista-de-operacoes/_index.md
@@ -1,10 +1,11 @@
 ---
 title: "Listar Operações"
 slug: "listar-operacoes"
-hidden: false
+hidden: true
 date: 2022-01-13T18:00:00.687Z
 lastmod: 2022-01-13T18:00:00.687Z
 weight: 3
+draft: true
 ---
 
 <br>


### PR DESCRIPTION
hide 'operations' because external partners can't use this part.