### PR TITLE
feat: add field to inbound pix payment received webhook

### DIFF
--- a/content/pt/docs/guias/WEBHOOKS/pix_inbound_payment_received.json
+++ b/content/pt/docs/guias/WEBHOOKS/pix_inbound_payment_received.json
@@ -44,6 +44,7 @@
         },
         "target_data": {
             "$ref": "inbound_pix_payment"
-        }
+        },
+        "paid_at": "string"
     }
 }


### PR DESCRIPTION
## Description

since the `pix_inbound_payment_received` webhook has a new field, we're updating the documentation.
